### PR TITLE
Correctly set the index value for __shf_up.

### DIFF
--- a/include/hip/amd_detail/amd_device_functions.h
+++ b/include/hip/amd_detail/amd_device_functions.h
@@ -425,7 +425,7 @@ inline
 int __shfl_up(int var, unsigned int lane_delta, int width = warpSize) {
     int self = __lane_id();
     int index = self - lane_delta;
-    index = (index < (self & ~(width-1)))?self:index;
+    index = (index < (self & ~(width-1)))?index:self;
     return __builtin_amdgcn_ds_bpermute(index<<2, var);
 }
 __device__


### PR DESCRIPTION
Please see https://www.khronos.org/registry/OpenCL/extensions/intel/cl_intel_subgroups.html for the details of the shuffles.

This was uncovered when writing libclc's Intel subgroup shuffles, which use the same built-in `bpermute` (https://github.com/intel/llvm/pull/4664/files) and was failing tests from llvm-test-suite (among others: https://github.com/intel/llvm-test-suite/blob/intel/SYCL/SubGroup/shuffle.hpp#L88).