### PR TITLE
[CMake] Fix fragile link line and also works better with hip-lang.

### DIFF
--- a/hip-config.cmake.in
+++ b/hip-config.cmake.in
@@ -120,13 +120,19 @@ else()
 endif()
 
 if(HIP_COMPILER STREQUAL "clang")
-  if(WIN32)
-    set(HIP_CLANG_ROOT "${HIP_PATH}")
-  else()
-    set(HIP_CLANG_ROOT "${ROCM_PATH}/llvm")
+  if(NOT HIP_CLANG_ROOT)
+    if(WIN32)
+      set(HIP_CLANG_ROOT "${HIP_PATH}")
+    else()
+      set(HIP_CLANG_ROOT "${ROCM_PATH}/llvm")
+    endif()
   endif()
   if(NOT HIP_CXX_COMPILER)
-    set(HIP_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+    if(CMAKE_HIP_COMPILER_WITH_PATH)
+      set(HIP_CXX_COMPILER ${CMAKE_HIP_COMPILER_WITH_PATH})
+    else()
+      set(HIP_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+    endif()
   endif()
   if(HIP_CXX_COMPILER MATCHES ".*hipcc" OR HIP_CXX_COMPILER MATCHES ".*clang\\+\\+")
     execute_process(COMMAND ${HIP_CXX_COMPILER} --version
@@ -242,11 +248,11 @@ if(HIP_COMPILER STREQUAL "clang")
   hip_add_interface_link_flags(hip::device --hip-link)
 
   set_property(TARGET hip::device APPEND PROPERTY
-    INTERFACE_INCLUDE_DIRECTORIES "${HIP_CLANG_INCLUDE_PATH}/.."
+    INTERFACE_INCLUDE_DIRECTORIES "${HIP_CLANG_INCLUDE_PATH}"
   )
 
   set_property(TARGET hip::device APPEND PROPERTY
-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HIP_CLANG_INCLUDE_PATH}/.."
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HIP_CLANG_INCLUDE_PATH}"
   )
 
   foreach(GPU_TARGET ${GPU_TARGETS})
@@ -271,8 +277,16 @@ if(HIP_COMPILER STREQUAL "clang")
   endif()
 
   # Add support for __fp16 and _Float16, explicitly link with compiler-rt
-  hip_add_interface_link_flags(hip::host   -L\"${HIP_CLANG_INCLUDE_PATH}/../lib/linux\" -lclang_rt.builtins-x86_64)
-  hip_add_interface_link_flags(hip::device -L\"${HIP_CLANG_INCLUDE_PATH}/../lib/linux\" -lclang_rt.builtins-x86_64)
+  file(GLOB HIP_CLANGRT_LIB_SEARCH_PATHS "${HIP_CLANG_ROOT}/lib/clang/*/lib/*")
+  find_library(CLANGRT_BUILTINS
+    NAMES
+      clang_rt.builtins-x86_64
+    PATHS
+      ${HIP_CLANGRT_LIB_SEARCH_PATHS}
+      ${HIP_CLANG_INCLUDE_PATH}/../lib/linux)
+
+  hip_add_interface_link_flags(hip::host   ${CLANGRT_BUILTINS})
+  hip_add_interface_link_flags(hip::device ${CLANGRT_BUILTINS})
 endif()
 
 set( hip_LIBRARIES hip::host hip::device)


### PR DESCRIPTION
Make it work better with HIP as language in CMake when https://github.com/ROCm-Developer-Tools/HIP/pull/2434 is added.

Remove using "-L". Never do this in CMake, it is a source of problems.
Following hip-lang-config. Just find_library.