### PR TITLE
Vector fixes

### DIFF
--- a/include/hip/amd_detail/amd_hip_vector_types.h
+++ b/include/hip/amd_detail/amd_hip_vector_types.h
@@ -811,7 +811,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         __HOST_DEVICE__
         HIP_vector_type& operator+=(const HIP_vector_type& x) noexcept
         {
-            data += x.data;
+            #if __has_attribute(ext_vector_type)
+                data += x.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    data[i] += x.data[i];
+            #endif
             return *this;
         }
         template<
@@ -827,7 +832,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         __HOST_DEVICE__
         HIP_vector_type& operator-=(const HIP_vector_type& x) noexcept
         {
-            data -= x.data;
+            #if __has_attribute(ext_vector_type)
+                data -= x.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    data[i] -= x.data[i];
+            #endif
             return *this;
         }
         template<
@@ -843,7 +853,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         __HOST_DEVICE__
         HIP_vector_type& operator*=(const HIP_vector_type& x) noexcept
         {
-            data *= x.data;
+            #if __has_attribute(ext_vector_type)
+                data *= x.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    data[i] *= x.data[i];
+            #endif
             return *this;
         }
         template<
@@ -859,7 +874,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         __HOST_DEVICE__
         HIP_vector_type& operator/=(const HIP_vector_type& x) noexcept
         {
-            data /= x.data;
+            #if __has_attribute(ext_vector_type)
+                data /= x.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    data[i] /= x.data[i];
+            #endif
             return *this;
         }
         template<
@@ -879,7 +899,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         HIP_vector_type operator-() const noexcept
         {
             auto tmp(*this);
-            tmp.data = -tmp.data;
+            #if __has_attribute(ext_vector_type)
+                tmp.data = -tmp.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    tmp.data[i] = -tmp.data[i];
+            #endif
             return tmp;
         }
 
@@ -890,7 +915,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         HIP_vector_type operator~() const noexcept
         {
             HIP_vector_type r{*this};
-            r.data = ~r.data;
+            #if __has_attribute(ext_vector_type)
+                r.data = ~r.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    r.data[i] = ~r.data[i];
+            #endif
             return r;
         }
 
@@ -900,7 +930,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         __HOST_DEVICE__
         HIP_vector_type& operator%=(const HIP_vector_type& x) noexcept
         {
-            data %= x.data;
+            #if __has_attribute(ext_vector_type)
+                data %= x.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    data[i] %= x.data[i];
+            #endif
             return *this;
         }
 
@@ -910,7 +945,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         __HOST_DEVICE__
         HIP_vector_type& operator^=(const HIP_vector_type& x) noexcept
         {
-            data ^= x.data;
+            #if __has_attribute(ext_vector_type)
+                data ^= x.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    data[i] ^= x.data[i];
+            #endif
             return *this;
         }
 
@@ -920,7 +960,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         __HOST_DEVICE__
         HIP_vector_type& operator|=(const HIP_vector_type& x) noexcept
         {
-            data |= x.data;
+            #if __has_attribute(ext_vector_type)
+                data |= x.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    data[i] |= x.data[i];
+            #endif
             return *this;
         }
 
@@ -930,7 +975,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         __HOST_DEVICE__
         HIP_vector_type& operator&=(const HIP_vector_type& x) noexcept
         {
-            data &= x.data;
+            #if __has_attribute(ext_vector_type)
+                data &= x.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    data[i] &= x.data[i];
+            #endif
             return *this;
         }
 
@@ -940,7 +990,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         __HOST_DEVICE__
         HIP_vector_type& operator>>=(const HIP_vector_type& x) noexcept
         {
-            data >>= x.data;
+            #if __has_attribute(ext_vector_type)
+                data >>= x.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    data[i] >>= x.data[i];
+            #endif
             return *this;
         }
 
@@ -950,7 +1005,12 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         __HOST_DEVICE__
         HIP_vector_type& operator<<=(const HIP_vector_type& x) noexcept
         {
-            data <<= x.data;
+            #if __has_attribute(ext_vector_type)
+                data <<= x.data;
+            #else
+                for (auto i = 0u; i < rank; ++i)
+                    data[i] <<= x.data[i];
+            #endif
             return *this;
         }
     };

--- a/include/hip/amd_detail/amd_hip_vector_types.h
+++ b/include/hip/amd_detail/amd_hip_vector_types.h
@@ -955,6 +955,13 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
         }
     };
 
+    // comfort type to only enable an operator if U can be converted to
+    // a HIP_vector_type<T, N>
+    template<typename U, typename T, unsigned int n,
+        typename R=HIP_vector_type<T, n> /* operator return value */>
+    using enable_if_convertible = typename
+        std::enable_if<std::is_convertible<U, HIP_vector_type<T, n>>::value, R>::type;
+
     template<typename T, unsigned int n>
     __HOST_DEVICE__
     inline
@@ -968,7 +975,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    HIP_vector_type<T, n> operator+(
+    enable_if_convertible<U, T, n> operator+(
         const HIP_vector_type<T, n>& x, U y) noexcept
     {
         return HIP_vector_type<T, n>{x} += HIP_vector_type<T, n>{y};
@@ -977,7 +984,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    HIP_vector_type<T, n> operator+(
+    enable_if_convertible<U, T, n> operator+(
         U x, const HIP_vector_type<T, n>& y) noexcept
     {
         return HIP_vector_type<T, n>{x} += y;
@@ -996,7 +1003,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    HIP_vector_type<T, n> operator-(
+    enable_if_convertible<U, T, n> operator-(
         const HIP_vector_type<T, n>& x, U y) noexcept
     {
         return HIP_vector_type<T, n>{x} -= HIP_vector_type<T, n>{y};
@@ -1005,7 +1012,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    HIP_vector_type<T, n> operator-(
+    enable_if_convertible<U, T, n> operator-(
         U x, const HIP_vector_type<T, n>& y) noexcept
     {
         return HIP_vector_type<T, n>{x} -= y;
@@ -1024,7 +1031,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    HIP_vector_type<T, n> operator*(
+    enable_if_convertible<U, T, n> operator*(
         const HIP_vector_type<T, n>& x, U y) noexcept
     {
         return HIP_vector_type<T, n>{x} *= HIP_vector_type<T, n>{y};
@@ -1033,7 +1040,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    HIP_vector_type<T, n> operator*(
+    enable_if_convertible<U, T, n> operator*(
         U x, const HIP_vector_type<T, n>& y) noexcept
     {
         return HIP_vector_type<T, n>{x} *= y;
@@ -1052,7 +1059,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    HIP_vector_type<T, n> operator/(
+    enable_if_convertible<U, T, n> operator/(
         const HIP_vector_type<T, n>& x, U y) noexcept
     {
         return HIP_vector_type<T, n>{x} /= HIP_vector_type<T, n>{y};
@@ -1061,7 +1068,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    HIP_vector_type<T, n> operator/(
+    enable_if_convertible<U, T, n> operator/(
         U x, const HIP_vector_type<T, n>& y) noexcept
     {
         return HIP_vector_type<T, n>{x} /= y;
@@ -1090,7 +1097,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    bool operator==(const HIP_vector_type<T, n>& x, U y) noexcept
+    enable_if_convertible<U, T, n, bool> operator==(const HIP_vector_type<T, n>& x, U y) noexcept
     {
         return x == HIP_vector_type<T, n>{y};
     }
@@ -1098,7 +1105,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    bool operator==(U x, const HIP_vector_type<T, n>& y) noexcept
+    enable_if_convertible<U, T, n, bool> operator==(U x, const HIP_vector_type<T, n>& y) noexcept
     {
         return HIP_vector_type<T, n>{x} == y;
     }
@@ -1116,7 +1123,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    bool operator!=(const HIP_vector_type<T, n>& x, U y) noexcept
+    enable_if_convertible<U, T, n, bool> operator!=(const HIP_vector_type<T, n>& x, U y) noexcept
     {
         return !(x == y);
     }
@@ -1124,7 +1131,7 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
     __HOST_DEVICE__
     inline
     constexpr
-    bool operator!=(U x, const HIP_vector_type<T, n>& y) noexcept
+    enable_if_convertible<U, T, n, bool> operator!=(U x, const HIP_vector_type<T, n>& y) noexcept
     {
         return !(x == y);
     }

--- a/include/hip/amd_detail/amd_hip_vector_types.h
+++ b/include/hip/amd_detail/amd_hip_vector_types.h
@@ -209,9 +209,15 @@ template <typename __T> struct is_scalar : public integral_constant<bool, __is_s
             Vector data;
 
             __HOST_DEVICE__
-            operator T() const noexcept { return data[idx]; }
+            constexpr operator const T&() const noexcept {
+                return reinterpret_cast<
+                    const T (&)[sizeof(Vector) / sizeof(T)]>(data)[idx];
+            }
             __HOST_DEVICE__
-            operator T() const volatile noexcept { return data[idx]; }
+            constexpr operator const volatile T&() const volatile noexcept {
+                return reinterpret_cast<
+                    const volatile T (&)[sizeof(Vector) / sizeof(T)]>(data)[idx];
+            }
 
 #ifdef __HIP_ENABLE_VECTOR_SCALAR_ACCESSORY_ENUM_CONVERSION__
             // The conversions to enum are fairly ghastly, but unfortunately used in


### PR DESCRIPTION
This patchset fixes the behavior of HIP vector types when used on host and building with a host compiler. Closes issues #3 and #4, that emerged while introducing HIP support in [GPUSPH](/GPUSPH/gpusph) and affect both g++ and clang++ as host compiler. The last patch also fixes operators that assume ext_vector_type is supported (which is not the case for g++).