### PR TITLE
Fix checking if hsa/hsa.h is found, use ROCM_PATH

### DIFF
--- a/hip-config.cmake.in
+++ b/hip-config.cmake.in
@@ -188,7 +188,7 @@ if(NOT WIN32)
   find_path(HSA_HEADER hsa/hsa.h
     PATHS
       "${_IMPORT_PREFIX}/../include"
-      /opt/rocm/include
+      "${ROCM_PATH}/include"
   )
 
   if (NOT HSA_HEADER)

--- a/hip-config.cmake.in
+++ b/hip-config.cmake.in
@@ -191,7 +191,7 @@ if(NOT WIN32)
       /opt/rocm/include
   )
 
-  if (HSA_HEADER-NOTFOUND)
+  if (NOT HSA_HEADER)
     message (FATAL_ERROR "HSA header not found! ROCM_PATH environment not set")
   endif()
 endif()


### PR DESCRIPTION
The old condition `HSA_HEADER-NOTFOUND` is always false.