### PR TITLE
Handled cudaMemoryTypeManaged in hipPointerGetAttributes

### DIFF
--- a/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -1719,6 +1719,9 @@ inline static hipError_t hipPointerGetAttributes(hipPointerAttribute_t* attribut
             case cudaMemoryTypeHost:
                 attributes->memoryType = hipMemoryTypeHost;
                 break;
+            case cudaMemoryTypeManaged:
+                attributes->memoryType = hipMemoryTypeUnified;
+                break;
             default:
                 return hipErrorInvalidValue;
         }

--- a/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -1707,10 +1707,10 @@ inline static hipError_t hipPointerGetAttributes(hipPointerAttribute_t* attribut
     struct cudaPointerAttributes cPA;
     hipError_t err = hipCUDAErrorTohipError(cudaPointerGetAttributes(&cPA, ptr));
     if (err == hipSuccess) {
-#if (CUDART_VERSION >= 11000)
-        auto memType = cPA.type;
+#if (CUDART_VERSION >= 10000)
+        cudaMemoryType memType = cPA.type;
 #else
-        unsigned memType = cPA.memoryType; // No auto because cuda 10.2 doesnt force c++11
+        cudaMemoryType memType = cPA.memoryType; // No auto because cuda 10.2 doesnt force c++11
 #endif
         switch (memType) {
             case cudaMemoryTypeDevice:
@@ -1719,9 +1719,11 @@ inline static hipError_t hipPointerGetAttributes(hipPointerAttribute_t* attribut
             case cudaMemoryTypeHost:
                 attributes->memoryType = hipMemoryTypeHost;
                 break;
+#if (CUDART_VERSION >= 10000)
             case cudaMemoryTypeManaged:
                 attributes->memoryType = hipMemoryTypeUnified;
                 break;
+#endif
             default:
                 return hipErrorInvalidValue;
         }


### PR DESCRIPTION
I've added support for cudaMemoryTypeManaged to hipPointerGetAttributes. The full list of memory types can be found here https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g13de56a8fe75569530ecc3a3106e9b6d

Also it looks like support for cudaPointerAttributes.type came in CUDA 10, and cudaPointerAttributes.memoryType was deprecated at the same time. The runtime api docs support this:
https://docs.nvidia.com/cuda/archive/9.2/cuda-runtime-api/structcudaPointerAttributes.html#structcudaPointerAttributes
https://docs.nvidia.com/cuda/archive/10.0/cuda-runtime-api/structcudaPointerAttributes.html#structcudaPointerAttributes

Getting this sorted would be helpful for SYCL's HIP for NVIDIA backend when using CUDA 11+ :smile: 