### PR TITLE
Fix missing return statement in hipModuleGetTexRef

### DIFF
--- a/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -2136,7 +2136,7 @@ inline static hipError_t hipModuleGetFunction(hipFunction_t* function, hipModule
 }
 
 inline static hipError_t hipModuleGetTexRef(hipTexRef* pTexRef, hipModule_t hmod, const char* name){
-    hipCUResultTohipError(cuModuleGetTexRef(pTexRef, hmod, name));
+    return hipCUResultTohipError(cuModuleGetTexRef(pTexRef, hmod, name));
 }
 
 inline static hipError_t hipFuncGetAttributes(hipFuncAttributes* attr, const void* func) {


### PR DESCRIPTION
Found because -Wreturn-type and -Wunused-result complained.