### PR TITLE
amd_detail: fix `atomicMax` and `atomicMin` for floating point types

### DIFF
--- a/include/hip/amd_detail/amd_hip_atomic.h
+++ b/include/hip/amd_detail/amd_hip_atomic.h
@@ -434,13 +434,15 @@ float atomicMin(float* address, float val) {
   #else
     unsigned int tmp {__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
   #endif
-  float value = __uint_as_float(tmp);
+  float assumed = __uint_as_float(tmp);
+  float old = assumed;
 
-  while (val < value) {
-    value = atomicCAS(address, value, val);
+  while (val < assumed && __float_as_uint(assumed) != __float_as_uint(old)) {
+    assumed = old;
+    old = atomicCAS(address, assumed, val);
   }
 
-  return value;
+  return old;
 }
 
 __device__
@@ -452,13 +454,15 @@ float atomicMin_system(float* address, float val) {
   #else
     unsigned int tmp {__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
   #endif
-  float value = __uint_as_float(tmp);
+  float assumed = __uint_as_float(tmp);
+  float old = assumed;
 
-  while (val < value) {
-    value = atomicCAS_system(address, value, val);
+  while (val < assumed && __float_as_uint(assumed) != __float_as_uint(old)) {
+    assumed = old;
+    old = atomicCAS_system(address, assumed, val);
   }
 
-  return value;
+  return old;
 }
 
 __device__
@@ -470,13 +474,15 @@ double atomicMin(double* address, double val) {
   #else
     unsigned long long tmp {__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
   #endif
-  double value = __longlong_as_double(tmp);
+  double assumed = __longlong_as_double(tmp);
+  double old = assumed;
 
-  while (val < value) {
-    value = atomicCAS(address, value, val);
+  while (val < assumed && __double_as_longlong(assumed) != __double_as_longlong(old)) {
+    assumed = old;
+    old = atomicCAS(address, assumed, val);
   }
 
-  return value;
+  return old;
 }
 
 __device__
@@ -488,13 +494,15 @@ double atomicMin_system(double* address, double val) {
   #else
     unsigned long long tmp {__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
   #endif
-  double value = __longlong_as_double(tmp);
+  double assumed = __longlong_as_double(tmp);
+  double old = assumed;
 
-  while (val < value) {
-    value = atomicCAS_system(address, value, val);
+  while (val < assumed && __double_as_longlong(assumed) != __double_as_longlong(old)) {
+    assumed = old;
+    old = atomicCAS_system(address, assumed, val);
   }
 
-  return value;
+  return old;
 }
 
 __device__
@@ -554,13 +562,15 @@ float atomicMax(float* address, float val) {
   #else
     unsigned int tmp {__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
   #endif
-  float value = __uint_as_float(tmp);
+    float assumed = __uint_as_float(tmp);
+    float old = assumed;
 
-  while (value < val) {
-    value = atomicCAS(address, value, val);
-  }
+    while (val > assumed && __float_as_uint(assumed) != __float_as_uint(old)) {
+      assumed = old;
+      old = atomicCAS(address, assumed, val);
+    }
 
-  return value;
+    return old;
 }
 
 __device__
@@ -572,13 +582,15 @@ float atomicMax_system(float* address, float val) {
   #else
     unsigned int tmp {__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
   #endif
-  float value = __uint_as_float(tmp);
+    float assumed = __uint_as_float(tmp);
+    float old = assumed;
 
-  while (value < val) {
-    value = atomicCAS_system(address, value, val);
-  }
+    while (val > assumed && __float_as_uint(assumed) != __float_as_uint(old)) {
+      assumed = old;
+      old = atomicCAS_system(address, assumed, val);
+    }
 
-  return value;
+    return old;
 }
 
 __device__
@@ -590,13 +602,15 @@ double atomicMax(double* address, double val) {
   #else
     unsigned long long tmp {__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
   #endif
-  double value = __longlong_as_double(tmp);
+  double assumed = __longlong_as_double(tmp);
+  double old = assumed;
 
-  while (value < val) {
-    value = atomicCAS(address, value, val);
+  while (val > assumed && __double_as_longlong(assumed) != __double_as_longlong(old)) {
+    assumed = old;
+    old = atomicCAS(address, assumed, val);
   }
 
-  return value;
+  return old;
 }
 
 __device__
@@ -608,13 +622,15 @@ double atomicMax_system(double* address, double val) {
   #else
     unsigned long long tmp {__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
   #endif
-  double value = __longlong_as_double(tmp);
+  double assumed = __longlong_as_double(tmp);
+  double old = assumed;
 
-  while (value < val) {
-      value = atomicCAS_system(address, value, val);
+  while (val > assumed && __double_as_longlong(assumed) != __double_as_longlong(old)) {
+    assumed = old;
+    old = atomicCAS_system(address, assumed, val);
   }
 
-  return value;
+  return old;
 }
 
 __device__


### PR DESCRIPTION
The return value of `atomicMax` and `atomicMin` should be the old value from the destination memory.
This was not the case before the fix.
In cases where no concurrent thread is manipulating the destination the returned values were always the value passed to the atomic function.

# test case (for float/double):
```C++
#include <assert.h>
#include <stdio.h>

#include "hip/hip_runtime.h"


template<typename T>
__global__ void testAtomicMin(bool* success, T operandOrig)
{
    __shared__ T operand;
    {
        T const value = operandOrig / static_cast<T>(2);
        T const reference = (operandOrig < value) ? operandOrig : value;
        operand = operandOrig;
        T const ret = atomicMin(&operand, value);
        printf("1: %lf==%lf %lf==%lf\n", double(operandOrig), double(ret), double(value),double(reference));
        assert(operandOrig == ret);
        assert(value == reference);
    }
    {

        T const value = static_cast<T>(2)*operandOrig;
        T const reference = (operandOrig < value) ? operandOrig : value;
        operand = operandOrig;
        T const ret = atomicMin(&operand, value);
        printf("2: %lf==%lf %lf==%lf\n", double(operandOrig), double(ret), double(operand),double(reference));

        assert(operandOrig == ret);
        assert(operand == reference);
    }
}

#define HIP_ASSERT(x) (assert((x)==hipSuccess))

int main() {

        bool* deviceResult;

        HIP_ASSERT(hipMalloc((void**)&deviceResult,sizeof(bool)));

        testAtomicMin<<<1,1>>>(deviceResult,42.f);
        testAtomicMin<<<1,1>>>(deviceResult,42);

        HIP_ASSERT(hipDeviceSynchronize());
        HIP_ASSERT(hipFree(deviceResult));


        return 0;
}
```

output:
```
1: 42.000000==21.000000 21.000000==21.000000
```