### PR TITLE
make nvidia_hip_runtime_api work with CUDA 12

### DIFF
--- a/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -2792,6 +2792,7 @@ inline static hipError_t hipFuncSetCacheConfig(const void* func, hipFuncCache_t 
     return hipCUDAErrorTohipError(cudaFuncSetCacheConfig(func, cacheConfig));
 }
 
+#if CUDA_VERSION < 12000
 __HIP_DEPRECATED inline static hipError_t hipBindTexture(size_t* offset,
                                                          struct textureReference* tex,
                                                          const void* devPtr,
@@ -2805,6 +2806,7 @@ __HIP_DEPRECATED inline static hipError_t hipBindTexture2D(
     const hipChannelFormatDesc* desc, size_t width, size_t height, size_t pitch) {
     return hipCUDAErrorTohipError(cudaBindTexture2D(offset, tex, devPtr, desc, width, height, pitch));
 }
+#endif // CUDA_VERSION < 12000
 
 inline static hipChannelFormatDesc hipCreateChannelDesc(int x, int y, int z, int w,
                                                         hipChannelFormatKind f) {
@@ -2837,10 +2839,12 @@ inline static hipError_t hipGetTextureObjectResourceDesc(hipResourceDesc* pResDe
     return hipCUDAErrorTohipError(cudaGetTextureObjectResourceDesc( pResDesc, textureObject));
 }
 
+#if CUDA_VERSION < 12000
 __HIP_DEPRECATED inline static hipError_t hipGetTextureAlignmentOffset(
     size_t* offset, const struct textureReference* texref) {
     return hipCUDAErrorTohipError(cudaGetTextureAlignmentOffset(offset,texref));
 }
+#endif // CUDA_VERSION < 12000
 
 inline static hipError_t hipGetChannelDesc(hipChannelFormatDesc* desc, hipArray_const_t array)
 {
@@ -3086,6 +3090,7 @@ inline static hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags( 
                                                                  blockSize, dynamicSMemSize, flags));
 }
 
+#if CUDA_VERSION < 12000
 template <class T, int dim, enum cudaTextureReadMode readMode>
 inline static hipError_t hipBindTexture(size_t* offset, const struct texture<T, dim, readMode>& tex,
                                         const void* devPtr, size_t size = UINT_MAX) {
@@ -3128,6 +3133,7 @@ __HIP_DEPRECATED inline static hipError_t hipBindTextureToArray(
     struct texture<T, dim, readMode>& tex, hipArray_const_t array) {
     return hipCUDAErrorTohipError(cudaBindTextureToArray(tex, array));
 }
+#endif // CUDA_VERSION < 12000
 
 template <class T>
 inline static hipChannelFormatDesc hipCreateChannelDesc() {


### PR DESCRIPTION
guard calls to deleted functions in `if` directives.

Fixes: https://github.com/ROCm-Developer-Tools/hipamd/issues/73